### PR TITLE
cd with only a relative or absolute path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,8 @@ SRC = src/main.c \
 	  src/parser/parser_node_utils.c \
 	  src/parser/parser_utils.c \
 	  src/executor/executor.c \
-	  src/executor/builtin_pwd.c
+	  src/executor/builtin_pwd.c \
+	  src/executor/builtin_cd.c \
 
 OBJECTS = $(SRC:.c=.o)
 DEBUG_OBJECTS = $(SRC:.c=_debug.o)

--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -6,7 +6,7 @@
 /*   By: aevstign <aevstign@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/11/27 18:12:25 by aevstign          #+#    #+#             */
-/*   Updated: 2024/12/19 15:27:25 by iasonov          ###   ########.fr       */
+/*   Updated: 2024/12/21 23:16:56 by iasonov          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -58,6 +58,7 @@ typedef struct s_ast_node
 {
 	t_node_type			type;
 	char				**args;
+	int					argc;
 	int					file_type;
 	struct s_ast_node	*left;
 	struct s_ast_node	*right;
@@ -100,4 +101,5 @@ void			execute_ast(t_ast_node *node);
 
 // executor
 void			builtin_pwd(void);
+void			builtin_cd(t_ast_node *node);
 #endif

--- a/src/executor/builtin_cd.c
+++ b/src/executor/builtin_cd.c
@@ -1,0 +1,31 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   builtin_cd.c                                       :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: iasonov <iasonov@student.42prague.com>     +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2024/12/21 23:17:21 by iasonov           #+#    #+#             */
+/*   Updated: 2024/12/21 23:35:21 by iasonov          ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "../../includes/minishell.h"
+
+void	builtin_cd(t_ast_node *node)
+{
+	if (node->argc < 2)
+	{
+		write(STDERR_FILENO, "cd: Missing argument\n", 21);
+		return ;
+	}
+	if (node->argc > 2)
+	{
+		write(STDERR_FILENO, "cd: too many arguments\n", 24);
+		return ;
+	}
+	if (chdir(node->args[1]) != 0)
+	{
+		perror("cd");
+	}
+}

--- a/src/executor/executor.c
+++ b/src/executor/executor.c
@@ -6,7 +6,7 @@
 /*   By: iasonov <iasonov@student.42prague.com>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/12/17 00:40:18 by iasonov           #+#    #+#             */
-/*   Updated: 2024/12/19 23:03:22 by iasonov          ###   ########.fr       */
+/*   Updated: 2024/12/21 23:17:06 by iasonov          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -18,6 +18,8 @@ void	execute_builtin(t_ast_node *node)
 	printf("resut: %d", ft_strcmp(node->args[0], "pwd"));
 	if (ft_strcmp(node->args[0], "pwd") == 0)
 		builtin_pwd();
+	else if (ft_strcmp(node->args[0], "cd") == 0)
+		builtin_cd(node);
 }
 
 void	execute_node(t_ast_node *node)

--- a/src/parser/parser.c
+++ b/src/parser/parser.c
@@ -6,7 +6,7 @@
 /*   By: aevstign <aevstign@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/12/01 22:31:45 by iasonov           #+#    #+#             */
-/*   Updated: 2024/12/18 23:10:18 by iasonov          ###   ########.fr       */
+/*   Updated: 2024/12/21 23:29:17 by iasonov          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -64,6 +64,7 @@ void	create_command_node(t_ast_node **current_node, t_list *list_item,
 			arg_count++;
 		(*current_node)->args[arg_count] = ft_strdup(token->value);
 		(*current_node)->args[arg_count + 1] = NULL;
+		(*current_node)->argc = arg_count + 1;
 	}
 	else
 		*current_node = create_ast_node(NODE_COMMAND, token->value, list_item);


### PR DESCRIPTION
- added cd handler;
	- works fine with absolute and relative path;
	- doesnt work with home folder e.g. ~/
- when less than 2 arguments we're failing, for example zsh navigates to home folder;

https://github.com/a3nv/42prague_minishell/issues/3