### PR TITLE
Add pair struct, string builder, and export function to minishell

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM ubuntu:22.04
+RUN apt-get update && apt-get install -y \
+    build-essential \
+	tmux \
+    gcc \
+    gdb \
+    valgrind \
+    make \
+    vim \
+    git \
+    && apt-get clean
+WORKDIR /app

--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,8 @@ SRC = src/main.c \
 	  src/executor/builtin_exit.c \
 	  src/executor/builtin_echo.c \
 	  src/executor/builtin_env.c \
+	  src/executor/builtin_export.c \
+	  src/executor/builtin_export_utils.c \
 
 OBJECTS = $(SRC:.c=.o)
 DEBUG_OBJECTS = $(SRC:.c=_debug.o)

--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -6,7 +6,7 @@
 /*   By: aevstign <aevstign@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/11/27 18:12:25 by aevstign          #+#    #+#             */
-/*   Updated: 2024/12/22 19:57:54 by iasonov          ###   ########.fr       */
+/*   Updated: 2024/12/26 23:50:08 by iasonov          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -78,7 +78,7 @@ t_state			*init(char **envp);
 
 // gc
 void			free_list(void *content);
-void			free_state(t_state *state);
+void			reset_state(t_state *state);
 
 // main utils
 void			print_tokens(t_list *lexer);
@@ -120,4 +120,11 @@ void			builtin_cd(t_ast_node *node);
 void			builtin_exit(t_state *state);
 void			builtin_echo(t_ast_node *node);
 void			builtin_env(t_state *state);
+void			builtin_export(t_ast_node *node, t_state *state);
+
+// builtin_export_utils
+int				count_env_vars(char	**envp);
+void			clear_copy(char **copy);
+t_pair			*parse_arg(char *arg);
+
 #endif

--- a/libft/Makefile
+++ b/libft/Makefile
@@ -6,7 +6,7 @@
 #    By: iasonov <iasonov@student.42.fr>            +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2024/05/22 22:56:57 by iasonov           #+#    #+#              #
-#    Updated: 2024/12/22 12:21:33 by iasonov          ###   ########.fr        #
+#    Updated: 2024/12/25 19:22:28 by iasonov          ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
@@ -55,6 +55,8 @@ SRC	=	ft_atoi.c		\
 		ft_tolower.c	\
 		ft_toupper.c	\
 		ft_write_fd.c	\
+		ft_str_builder.c	\
+		ft_pair.c	\
 		gnl/gnl.c 		\
 		gnl/gnl_utils.c	\
 		hashmap/hashmap.c \

--- a/libft/ft_pair.c
+++ b/libft/ft_pair.c
@@ -1,21 +1,28 @@
 /* ************************************************************************** */
 /*                                                                            */
 /*                                                        :::      ::::::::   */
-/*   builtin_exit.c                                     :+:      :+:    :+:   */
+/*   ft_pair.c                                          :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
 /*   By: iasonov <iasonov@student.42prague.com>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
-/*   Created: 2024/12/22 13:30:33 by iasonov           #+#    #+#             */
-/*   Updated: 2024/12/22 13:31:45 by iasonov          ###   ########.fr       */
+/*   Created: 2024/12/25 00:33:00 by iasonov           #+#    #+#             */
+/*   Updated: 2024/12/26 23:50:33 by iasonov          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
-#include "../../includes/minishell.h"
+#include "libft.h"
+#include <stdlib.h>
 
-void	builtin_exit(t_state *state)
+t_pair	*create_pair(char *first, char *second)
 {
-	reset_state(state);
-	free(state);
-	ft_write("Exiting minishell\n", STDOUT_FILENO);
-	exit(EXIT_SUCCESS);
+	t_pair	*pair;
+
+	if (!first || !second)
+		return (NULL);
+	pair = (t_pair *) malloc(sizeof(t_pair));
+	if (!pair)
+		return (NULL);
+	pair->first = first;
+	pair->second = second;
+	return (pair);
 }

--- a/libft/ft_str_builder.c
+++ b/libft/ft_str_builder.c
@@ -1,0 +1,38 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   ft_str_builder.c                                   :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: iasonov <iasonov@student.42prague.com>     +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2024/12/25 18:41:52 by iasonov           #+#    #+#             */
+/*   Updated: 2024/12/26 23:51:38 by iasonov          ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "libft.h"
+#include <stdio.h>
+
+void	ft_str_builder(char *res, size_t res_size, ...)
+{
+	va_list		ap;
+	const char	*current;
+	size_t		rem_space;
+	size_t		offset;
+	size_t		coppied;
+
+	va_start(ap, res_size);
+	current = va_arg(ap, const char *);
+	rem_space = res_size;
+	offset = 0;
+	while (current != NULL)
+	{
+		coppied = ft_strlcpy(res + offset, current, rem_space);
+		if (coppied >= rem_space)
+			break ;
+		offset += coppied;
+		rem_space -= coppied;
+		current = va_arg(ap, const char *);
+	}
+	va_end(ap);
+}

--- a/libft/libft.h
+++ b/libft/libft.h
@@ -6,7 +6,7 @@
 /*   By: iasonov <iasonov@student.42prague.com>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/05/22 22:49:26 by iasonov           #+#    #+#             */
-/*   Updated: 2024/12/22 12:23:52 by iasonov          ###   ########.fr       */
+/*   Updated: 2024/12/25 19:19:53 by iasonov          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -16,6 +16,7 @@
 # include <stddef.h>
 # include <stdlib.h>
 # include <unistd.h>
+# include <stdarg.h>
 
 # ifndef BUFFER_SIZE
 #  define BUFFER_SIZE 42
@@ -51,6 +52,7 @@ void		*ft_calloc(size_t count, size_t size);
 char		*ft_strdup(const char *s1);
 char		*ft_strndup(const char *src, size_t n);
 void		ft_write(char *s, int fd);
+void		ft_str_builder(char *res, size_t res_size, ...);
 
 // Part 2 - Additional functions
 char		*ft_substr(char const *s, unsigned int start, size_t len);
@@ -111,5 +113,14 @@ int			ft_hashmap_insert(t_hashmap *map,
 				const char *key, const char *value);
 char		*ft_hashmap_get(t_hashmap *map, const char *key);
 void		ft_hashmap_free(t_hashmap *map);
-#
+
+typedef struct s_pair
+{
+	void	*first;
+	void	*second;
+}	t_pair;
+
+// t_pair
+t_pair		*create_pair(char *first, char *second);
+
 #endif

--- a/src/executor/builtin_export.c
+++ b/src/executor/builtin_export.c
@@ -1,0 +1,113 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   builtin_export.c                                   :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: iasonov <iasonov@student.42prague.com>     +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2024/12/24 00:27:12 by iasonov           #+#    #+#             */
+/*   Updated: 2024/12/26 23:58:17 by iasonov          ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "../../includes/minishell.h"
+
+int	find_matched_key(char *key, char **envp)
+{
+	int	i;
+	int	key_len;
+
+	i = 0;
+	key_len = ft_strlen(key);
+	while (envp[i])
+	{
+		if (ft_strncmp(key, envp[i], key_len) == 0 && envp[i][key_len] == '=')
+			return (i);
+		i++;
+	}
+	return (-1);
+}
+
+char	**copy_envp(char **original)
+{
+	int		count;
+	int		i;
+	char	**nenvp;
+
+	count = count_env_vars(original);
+	nenvp = malloc((count + 2) * sizeof(char *));
+	if (!nenvp)
+		return (NULL);
+	i = 0;
+	while (original[i])
+	{
+		nenvp[i] = ft_strdup(original[i]);
+		if (!nenvp[i])
+		{
+			clear_copy(nenvp);
+			return (NULL);
+		}
+		i++;
+	}
+	return (nenvp);
+}
+
+void	add_env(t_pair *pair, char ***envp)
+{
+	int		envp_len;
+	int		entry_len;
+	char	**nenvp;
+
+	nenvp = copy_envp(*envp);
+	envp_len = count_env_vars(*envp);
+	entry_len = ft_strlen(pair->first) + ft_strlen(pair->second) + 2;
+	nenvp[envp_len] = malloc(entry_len);
+	if (!nenvp[envp_len])
+	{
+		clear_copy(nenvp);
+		return ;
+	}
+	ft_str_builder(nenvp[envp_len], entry_len, pair->first, "=",
+		pair->second, NULL);
+	nenvp[envp_len + 1] = NULL;
+	envp_len = 0;
+	*envp = nenvp;
+}
+
+void	update_env(t_pair *new_env, char ***envp, int mathed_index)
+{
+	char	*new_arg;
+	int		new_len;
+
+	new_len = ft_strlen(new_env->first) + ft_strlen(new_env->second) + 2;
+	new_arg = malloc(new_len);
+	ft_str_builder(new_arg, new_len, new_env->first, "=",
+		new_env->second, NULL);
+	free(envp[mathed_index]);
+	(*envp)[mathed_index] = new_arg;
+}
+
+/**
+ * todo: clear pair after use
+ */
+void	builtin_export(t_ast_node *node, t_state *state)
+{
+	int		i;
+	int		match;
+	char	*arg;
+	t_pair	*pair;
+
+	i = 1;
+	arg = node->args[i];
+	while (arg)
+	{
+		pair = parse_arg(arg);
+		match = find_matched_key(pair->first, state->envp);
+		if (match == -1)
+			add_env(pair, &state->envp);
+		else
+			update_env(pair, &state->envp, match);
+		i++;
+		arg = node->args[i];
+	}
+}

--- a/src/executor/builtin_export_utils.c
+++ b/src/executor/builtin_export_utils.c
@@ -1,0 +1,55 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   builtin_export_utils.c                             :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: iasonov <iasonov@student.42prague.com>     +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2024/12/25 17:47:56 by iasonov           #+#    #+#             */
+/*   Updated: 2024/12/26 23:56:10 by iasonov          ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "../../includes/minishell.h"
+
+int	count_env_vars(char	**envp)
+{
+	int	i;
+
+	i = 0;
+	while (envp[i])
+		i++;
+	return (i);
+}
+
+void	clear_copy(char **copy)
+{
+	int	i;
+
+	i = 0;
+	while (copy[i])
+	{
+		free(copy[i]);
+		i++;
+	}
+	free(copy);
+}
+
+/**
+ * todo: both key an value might be NULL handle this
+ */
+t_pair	*parse_arg(char *arg)
+{
+	char	*separator_pt;
+	long	key_index;
+	char	*key;
+	char	*value;
+
+	separator_pt = ft_strchr(arg, '=');
+	if (!separator_pt)
+		return (NULL);
+	key_index = separator_pt - arg;
+	key = ft_strndup(arg, key_index);
+	value = ft_strdup(separator_pt + 1);
+	return (create_pair(key, value));
+}

--- a/src/executor/executor.c
+++ b/src/executor/executor.c
@@ -6,7 +6,7 @@
 /*   By: iasonov <iasonov@student.42prague.com>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/12/17 00:40:18 by iasonov           #+#    #+#             */
-/*   Updated: 2024/12/22 20:31:49 by iasonov          ###   ########.fr       */
+/*   Updated: 2024/12/25 19:17:41 by iasonov          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -25,6 +25,8 @@ void	execute_builtin(t_ast_node *node, t_state *state)
 		builtin_echo(node);
 	else if (ft_strcmp(node->args[0], "env") == 0)
 		builtin_env(state);
+	else if (ft_strcmp(node->args[0], "export") == 0)
+		builtin_export(node, state);
 }
 
 void	execute_node(t_ast_node *node, t_state *state)

--- a/src/gc/gc.c
+++ b/src/gc/gc.c
@@ -6,7 +6,7 @@
 /*   By: iasonov <iasonov@student.42prague.com>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/12/22 13:04:47 by iasonov           #+#    #+#             */
-/*   Updated: 2024/12/22 13:19:51 by iasonov          ###   ########.fr       */
+/*   Updated: 2024/12/26 23:52:00 by iasonov          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -31,7 +31,7 @@ void	free_ast(t_ast_node *root_node)
 	free(root_node);
 }
 
-void	free_state(t_state *state)
+void	reset_state(t_state *state)
 {
 	if (state->input)
 		free(state->input);
@@ -39,5 +39,4 @@ void	free_state(t_state *state)
 		ft_lstclear(&state->token_list, free_list);
 	if (state->root_node)
 		free_ast(state->root_node);
-	free(state);
 }

--- a/src/main.c
+++ b/src/main.c
@@ -57,9 +57,9 @@ int	main(int argc, char **argv, char **envp)
 	(void)argc;
 	(void)argv;
 	print_debug_info();
+	state = init(envp);
 	while (1)
 	{
-		state = init(envp);
 		ft_write("minishell$> ", STDOUT_FILENO);
 		state->input = read_input();
 		state->token_list = lexer(state->input);
@@ -73,7 +73,7 @@ int	main(int argc, char **argv, char **envp)
 			ft_write("Entered: ", STDOUT_FILENO);
 			ft_write(state->input, STDOUT_FILENO);
 		}
-		free_state(state);
+		reset_state(state);
 	}
 	return (0);
 }


### PR DESCRIPTION
Changes included in this commit:

- Added pair struct to libft.
- Added string builder function to libft.
- Implemented export function to handle environment variables.

This addresses https://github.com/a3nv/42prague_minishell/issues/5

Note:
Environment variables appear to persist only during minishell execution. The BRD (Business Requirements Document) does not specify behavior beyond this scope.